### PR TITLE
#23バリデーション関連のバグの修正

### DIFF
--- a/laravel/app/Http/Controllers/Api/Admin/UserController.php
+++ b/laravel/app/Http/Controllers/Api/Admin/UserController.php
@@ -66,8 +66,10 @@ class UserController extends ApiController
     public function update(UserUpdateRequest $request, string $id): JsonResponse
     {
         try {
+            $validated = $request->passedValidation();
+
             $user = $this->userRepository->getOneById($id);
-            $user->fill($request->all());
+            $user->fill($validated);
             $user->save();
         } catch (QueryException $e) {
             return $this->respondInvalidQuery();

--- a/laravel/app/Http/Controllers/Api/AdminUserController.php
+++ b/laravel/app/Http/Controllers/Api/AdminUserController.php
@@ -51,18 +51,14 @@ class AdminUserController extends ApiController
     /**
      * 管理者編集
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  AdminUserUpdateRequest  $request
      * @param int $id
      * @return JsonResponse
      */
     public function update(AdminUserUpdateRequest $request, int $id): JsonResponse
     {
         try {
-            $validated = $request->validated();
-
-            if (isset($validated['password'])) {
-                $validated['password'] = Hash::make($validated['password']);
-            }
+            $validated = $request->passedValidation();
 
             $adminUser = AdminUser::findOrFail($id);
             $adminUser->fill($validated);

--- a/laravel/app/Http/Controllers/Api/AdminUserController.php
+++ b/laravel/app/Http/Controllers/Api/AdminUserController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers\Api;
 
 use App\AdminUser;
-use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
 use App\Http\Requests\AdminUserStoreRequest;
 use App\Http\Requests\AdminUserUpdateRequest;
@@ -16,9 +15,9 @@ class AdminUserController extends ApiController
     /**
      * 管理者一覧
      *
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Http\JsonResponse
      */
-    public function index()
+    public function index(): JsonResponse
     {
         $data = AdminUser::all();
 
@@ -30,10 +29,10 @@ class AdminUserController extends ApiController
     /**
      * 管理者登録
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response
+     * @param  AdminUserStoreRequest $request
+     * @return \Illuminate\Http\JsonResponse
      */
-    public function store(AdminUserStoreRequest $request)
+    public function store(AdminUserStoreRequest $request): JsonResponse
     {
         try {
             AdminUser::create([

--- a/laravel/app/Http/Requests/AdminUserUpdateRequest.php
+++ b/laravel/app/Http/Requests/AdminUserUpdateRequest.php
@@ -31,7 +31,7 @@ class AdminUserUpdateRequest extends ApiRequest
             'id' => 'required',
             'name' => 'required',
             'email' => ['required', Rule::unique('App\AdminUser')->ignore($this->id)],
-            'password' => new PasswordRule(),
+            'password' => ['sometimes', new PasswordRule()],
         ];
     }
 
@@ -42,5 +42,25 @@ class AdminUserUpdateRequest extends ApiRequest
             'email.required' => 'Eメールは必須です。',
             'email.unique' => '入力したEメールはすでに存在しています。',
         ];
+    }
+
+    /**
+     * バリデーション通過後、パスワードがリクエストにあればハッシュ化したものをリクエストパラメータにセット
+     *
+     * @return void
+     */
+    public function passedValidation(): array
+    {
+        $request = $this->all();
+
+        if ($this->filled('password')) {
+            $password = Hash::make($request['password']);
+            $this->merge(['password' => $password]);
+        } else {
+            // パスワードがNULLだとDBに保存できずエラーになるため、リクエストから削除
+            unset($request['password']);
+        }
+
+        return $request;
     }
 }

--- a/laravel/app/Http/Requests/AdminUserUpdateRequest.php
+++ b/laravel/app/Http/Requests/AdminUserUpdateRequest.php
@@ -31,7 +31,7 @@ class AdminUserUpdateRequest extends ApiRequest
             'id' => 'required',
             'name' => 'required',
             'email' => ['required', Rule::unique('App\AdminUser')->ignore($this->id)],
-            'password' => ['sometimes', new PasswordRule()],
+            'password' => ['nullable', new PasswordRule()],
         ];
     }
 

--- a/laravel/app/Http/Requests/UserUpdateRequest.php
+++ b/laravel/app/Http/Requests/UserUpdateRequest.php
@@ -30,7 +30,7 @@ class UserUpdateRequest extends ApiRequest
             'id' => 'required',
             'name' => 'required',
             'email' => ['required', Rule::unique('App\Models\User')->ignore($this->id)],
-            'password' => ['nullable', new PasswordRule()]
+            'password' => ['nullable', new PasswordRule()],
         ];
     }
 
@@ -48,14 +48,18 @@ class UserUpdateRequest extends ApiRequest
      *
      * @return void
      */
-    public function passedValidation(): void
+    public function passedValidation(): array
     {
-        $password = $this->get('password');
+        $request = $this->all();
 
         if ($this->filled('password')) {
-            $password = Hash::make($password);
+            $password = Hash::make($request['password']);
+            $this->merge(['password' => $password]);
+        } else {
+            // パスワードがNULLだとDBに保存できずエラーになるため、リクエストから削除
+            unset($request['password']);
         }
 
-        $this->merge(['password' => $password]);
+        return $request;
     }
 }

--- a/nuxt/components/admin/admin/Create.vue
+++ b/nuxt/components/admin/admin/Create.vue
@@ -26,7 +26,7 @@
           >
           </v-text-field>
         </validation-provider>
-        <validation-provider v-slot="{ errors }" name="Email" rules="required">
+        <validation-provider v-slot="{ errors }" name="Email" rules="required|email">
           <v-text-field
             v-model="form.email"
             label="Email"

--- a/nuxt/components/admin/users/Create.vue
+++ b/nuxt/components/admin/users/Create.vue
@@ -26,7 +26,7 @@
           >
           </v-text-field>
         </validation-provider>
-        <validation-provider v-slot="{ errors }" name="Email" rules="required">
+        <validation-provider v-slot="{ errors }" name="Email" rules="required|email">
           <v-text-field
             v-model="form.email"
             label="Email"

--- a/nuxt/components/admin/users/Edit.vue
+++ b/nuxt/components/admin/users/Edit.vue
@@ -2,7 +2,7 @@
   <v-dialog v-model="dialog" width="600px">
     <v-card>
       <v-card-title>
-        <span class="text-h5">管理者編集</span>
+        <span class="text-h5">ユーザー編集</span>
       </v-card-title>
       <div v-if="Object.keys(validationErrors).length > 0">
         <v-alert

--- a/nuxt/pages/admin/users/index.vue
+++ b/nuxt/pages/admin/users/index.vue
@@ -70,7 +70,6 @@ export default {
       this.$axios
         .$get("users")
         .then((res) => {
-          console.log(res.data);
           this.loading = false;
           this.users = res.data;
         })

--- a/nuxt/store/auth.js
+++ b/nuxt/store/auth.js
@@ -15,7 +15,6 @@ export const actions = {
       .catch(err => {
         console.log(err);
       });
-    console.log(response);
     commit("setAdminUser", response);
   },
   async logout({ commit }) {


### PR DESCRIPTION
## Bugfix
* #23 

## Fix
- 以下全てユーザー管理、管理者管理共通の修正
  * 編集画面でパスワードが入力されない場合ば、リクエストから`password`キーをunsetする実装をリクエストフォームに記載
  * 必要ないデバッグコードの削除や、帰り値の型の記述、PHPDocsの修正を行った
  * フロントでemailバリデーションを追加

## 動作確認
* ローカルポチポチして確認

close #23 
