### PR TITLE
[タスク]ユーザー管理ページのユーザー一覧のページネーション化

### DIFF
--- a/nuxt/components/admin/admin/Delete.vue
+++ b/nuxt/components/admin/admin/Delete.vue
@@ -40,7 +40,7 @@ export default {
           if (res.deleted) {
             this.close();
             this.$toast.global.success_message({ message: "削除しました" });
-            //FIXME: リロードしないと、$refsが何故かundefinedになってしまい削除できないのでやむなく強制リロード
+            //FIXME: リロードしないと、$refsが何故かundefinedになってしまい削除できないのでやむなく強制リロード(ページネーションさせるとうまくうごくかも？)
             this.$router.go({
               path: this.$router.currentRoute.path,
               force: true,

--- a/nuxt/components/admin/users/Delete.vue
+++ b/nuxt/components/admin/users/Delete.vue
@@ -38,13 +38,9 @@ export default {
         .$delete(`/users/${item.id}`)
         .then((res) => {
           if (res.deleted) {
+            this.$emit("get-users");
             this.close();
             this.$toast.global.success_message({ message: "削除しました" });
-            //FIXME: リロードしないと、$refsが何故かundefinedになってしまい削除できないのでやむなく強制リロード
-            this.$router.go({
-              path: this.$router.currentRoute.path,
-              force: true,
-            });
           }
         })
         .catch((err) => {

--- a/nuxt/pages/admin/users/index.vue
+++ b/nuxt/pages/admin/users/index.vue
@@ -37,7 +37,7 @@
           </v-icon>
           <Edit ref="openEditModal" />
           <v-icon small @click="openDeleteModal(item)"> mdi-delete </v-icon>
-          <Delete ref="openDeleteModal" @get-admin-users="getUsers" />
+          <Delete ref="openDeleteModal" @get-users="getUsers" />
         </template>
       </v-data-table>
     </v-card>


### PR DESCRIPTION
## チケットへのリンク

* #25 

## やったこと
- ユーザー管理ページのページネーション化
  - ページネーション毎にAPIを叩き10件だけデータを取得するようにした。
## やらないこと

* 無し

## できるようになること（ユーザ目線）

* ユーザーが増えてもページが重くならなくなる。

## できなくなること（ユーザ目線）

* 無し

## 動作確認

* ポチポチして確認

close #25
